### PR TITLE
Feature/figuring out authentication split

### DIFF
--- a/go-backend/go.mod
+++ b/go-backend/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect

--- a/go-backend/go.sum
+++ b/go-backend/go.sum
@@ -8,6 +8,8 @@ github.com/gofiber/fiber/v2 v2.41.0 h1:YhNoUS/OTjEz+/WLYuQ01xI7RXgKEFnGBKMagAu5f
 github.com/gofiber/fiber/v2 v2.41.0/go.mod h1:RdebcCuCRFp4W6hr3968/XxwJVg0K+jr9/Ae0PFzZ0Q=
 github.com/gofiber/fiber/v2 v2.42.0 h1:Fnp7ybWvS+sjNQsFvkhf4G8OhXswvB6Vee8hM/LyS+8=
 github.com/gofiber/fiber/v2 v2.42.0/go.mod h1:3+SGNjqMh5VQH5Vz2Wdi43zTIV16ktlFd3x3R6O1Zlc=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/go-backend/handlers/keys.go
+++ b/go-backend/handlers/keys.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"errors"
+	"geek-stash/models"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt"
+	"gorm.io/gorm"
+)
+
+
+func generateJwt ( uuid *string ) (*string, error) {
+
+	if uuid == nil {
+		return nil, errors.New("empty uuid")
+	}
+
+	token := jwt.New(jwt.SigningMethodHS256)
+
+	claims := token.Claims.(jwt.MapClaims)
+
+	claims["sub"] = uuid;
+	claims["authorized"] = true;
+	key := []byte(os.Getenv("AUTH0_SECRET"))
+	tokenString, err := token.SignedString(key)
+
+	if err != nil {
+		log.Printf("Unable to sign jwt:: %s ", err)
+		return nil, err
+	}
+
+	return &tokenString, nil
+}
+
+func KeyGen ( db *gorm.DB, ctx *fiber.Ctx ) error {
+
+	log.Printf("%v", ctx.GetReqHeaders())
+
+	auth_id := ctx.GetReqHeaders()["X-Auth-Id"]
+
+	if auth_id == "" {
+		ctx.Status(http.StatusUnauthorized).JSON(&fiber.Map{
+			"message": "Unauthorized",
+			"data": nil,
+			"status": 200,
+		})
+		return errors.New("auth ID is empty, request unauthorized")
+	}
+
+	profile := &models.Profile{}
+
+	err := db.Model(&models.Profile{}).First(profile, "auth_id = ?", auth_id).Error
+
+	if err != nil {
+		ctx.Status(http.StatusNotFound).JSON(&fiber.Map{
+			"message": "User not found",
+			"data": nil,
+			"status": 404,
+		})
+		return err
+	}
+	str := profile.ID.String()
+	token, terr := generateJwt(&str)
+
+	if terr != nil {
+		ctx.Status(http.StatusInternalServerError).JSON(&fiber.Map{
+			"message": terr,
+			"data": nil,
+			"status": 500,
+		})
+		return terr
+	}
+
+	key := &models.Keys{
+		Key: *token,
+		Owner: profile.ID,
+	}
+
+	err = db.Create(key).Error
+
+	if err != nil {
+		ctx.Status(http.StatusInternalServerError).JSON(&fiber.Map{
+			"message": err,
+			"data": nil,
+			"status": 500,
+		})
+		return err
+	}
+
+	ctx.Status(http.StatusCreated).JSON(&fiber.Map{
+		"message": "Success",
+		"data": nil,
+		"status": 201,
+	})
+
+	
+
+	return nil
+
+}

--- a/go-backend/handlers/place.go
+++ b/go-backend/handlers/place.go
@@ -40,3 +40,5 @@ func CreatePlace(db *gorm.DB, context *fiber.Ctx) error {
 	})
 	return nil
 }
+
+

--- a/go-backend/middleware/auth.go
+++ b/go-backend/middleware/auth.go
@@ -1,0 +1,100 @@
+package middleware
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt"
+	uuid "github.com/satori/go.uuid"
+	"gorm.io/gorm"
+)
+
+func Auth (ctx *fiber.Ctx) error {
+
+	if ctx.Path() != "/api/keys/new" {
+		authorization := ctx.GetReqHeaders()["Authorization"]
+
+		if authorization == "" {
+			return ctx.Status(http.StatusUnauthorized).JSON(&fiber.Map{
+				"message": "Unauthorized",
+				"data": nil,
+				"status": 401,
+			})
+			
+		} 
+		// Bearer 
+
+		tokenString := authorization[7:]
+		
+		token, err := jwt.Parse(tokenString, func(token *jwt.Token)(interface{}, error){
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+			}
+			return []byte(os.Getenv("AUTH0_SECRET")), nil
+		})
+		
+		if err != nil {
+			return ctx.Status(http.StatusUnauthorized).SendString("Invalid ")
+		}
+
+		if _, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+			log.Printf("Moving to function");
+			ctx.Locals("uid", tokenString)
+			if err != nil {
+				return ctx.Status(http.StatusInternalServerError).SendString("Unauthorized")
+			}
+
+			return ctx.Next()
+		} else {
+			return ctx.Status(401).SendString("Invalid token")
+		}
+
+
+	} else {
+		if ctx.GetReqHeaders()["X-Auth-Id"] != "" {
+			return ctx.SendStatus(401)
+		} else {
+			// fix this later
+			return ctx.Next()
+		}
+	}	
+
+}
+
+type nUID struct {
+	UID		*uuid.UUID		`json:"uid"`
+}
+
+
+func SetDBSession (db *gorm.DB, ctx *fiber.Ctx) {
+
+	gen_err := db.Connection(func (tx *gorm.DB) error {
+		err := tx.Exec(fmt.Sprintf(`select login('%s');`, ctx.Locals("uid"))).Error
+
+		if err != nil {
+			log.Printf("An error occured setting session %s", err)
+			return err
+		}
+		r := &nUID{}
+		err = tx.Raw(`
+		select regexp_replace(nullif(current_setting('request.jwt.claim.sub', true), ''), '"', '', 'g')::uuid as uid;
+		`).Scan(r).Error
+
+		if err != nil {
+			log.Printf(`An error occured %v`, err)
+			return err
+		}
+
+		log.Printf(`UID :: %v`, r)
+		return nil
+	})
+
+	if gen_err != nil {
+		log.Printf("An error occured with this transaction:: %s", gen_err)
+	}
+	
+
+}

--- a/go-backend/models/extensions/extensions.go
+++ b/go-backend/models/extensions/extensions.go
@@ -1,0 +1,136 @@
+package extensions
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+func addPgJwt (db *gorm.DB) {
+
+	err := db.Exec(`
+	CREATE SCHEMA if not exists jwt;
+	
+	CREATE OR REPLACE FUNCTION jwt.url_encode(data BYTEA)
+	  RETURNS TEXT LANGUAGE SQL AS $$
+	SELECT translate(encode(data, 'base64'), E'+/=\n', '-_');
+	$$;
+	
+	CREATE OR REPLACE FUNCTION jwt.url_decode(data TEXT)
+	  RETURNS BYTEA LANGUAGE SQL AS $$
+	WITH t AS (SELECT translate(data, '-_', '+/')),
+		rem AS (SELECT length((SELECT *
+							   FROM t)) % 4) -- compute padding size
+	SELECT decode(
+		(SELECT *
+		 FROM t) ||
+		CASE WHEN (SELECT *
+				   FROM rem) > 0
+		  THEN repeat('=', (4 - (SELECT *
+								 FROM rem)))
+		ELSE '' END,
+		'base64');
+	$$;
+	
+	
+	CREATE OR REPLACE FUNCTION jwt.algorithm_sign(signables TEXT, secret TEXT, algorithm TEXT)
+	  RETURNS TEXT LANGUAGE SQL AS $$
+	WITH
+		alg AS (
+		  SELECT CASE
+				 WHEN algorithm = 'HS256'
+				   THEN 'sha256'
+				 WHEN algorithm = 'HS384'
+				   THEN 'sha384'
+				 WHEN algorithm = 'HS512'
+				   THEN 'sha512'
+				 ELSE '' END) -- hmac throws error
+	SELECT jwt.url_encode(public.hmac(signables, secret, (SELECT *
+												   FROM alg)));
+	$$;
+	
+	
+	CREATE OR REPLACE FUNCTION jwt.sign(payload JSON, secret TEXT, algorithm TEXT DEFAULT 'HS256')
+	  RETURNS TEXT LANGUAGE SQL AS $$
+	WITH
+		header AS (
+		  SELECT jwt.url_encode(convert_to('{"alg":"' || algorithm || '","typ":"JWT"}', 'utf8'))
+	  ),
+		payload AS (
+		  SELECT jwt.url_encode(convert_to(payload :: TEXT, 'utf8'))
+	  ),
+		signables AS (
+		  SELECT (SELECT *
+				  FROM header) || '.' || (SELECT *
+										  FROM payload)
+	  )
+	SELECT (SELECT *
+			FROM signables)
+		   || '.' ||
+		   jwt.algorithm_sign((SELECT *
+							   FROM signables), secret, algorithm);
+	$$;
+	
+	
+	CREATE OR REPLACE FUNCTION jwt.verify(token TEXT, secret TEXT, algorithm TEXT DEFAULT 'HS256')
+	  RETURNS TABLE(header JSON, payload JSON, valid BOOLEAN) LANGUAGE SQL AS $$
+	SELECT
+	  convert_from(jwt.url_decode(r [1]), 'utf8') :: JSON                  AS header,
+	  convert_from(jwt.url_decode(r [2]), 'utf8') :: JSON                  AS payload,
+	  r [3] = jwt.algorithm_sign(r [1] || '.' || r [2], secret, algorithm) AS valid
+	FROM regexp_split_to_array(token, '\.') r;
+	$$;
+	`).Error
+
+
+	if err != nil {
+		log.Fatalf("An error occured while adding pgjwt:: %s", err)
+	}
+}
+
+func addExtension ( extension_name string, db *gorm.DB )  {
+
+	var create_name string;
+
+	if (strings.Contains(extension_name, "-")) {
+		create_name = fmt.Sprintf(`"%s"`, extension_name)
+	} else {
+		create_name = extension_name
+	}
+
+	str := fmt.Sprintf(`
+		do $$
+			begin
+				if not exists ( 
+					select 1 from pg_extension where extname = '%s'
+				) then
+				create extension %s;
+				end if;
+			end $$;
+	`,extension_name, create_name)
+
+     err := db.Exec(str).Error
+
+	 if err != nil {
+		log.Fatalf("Unable to add extension %s; error:: %s", extension_name, err)
+	 }
+	
+}
+
+func MigrateExtensions(db *gorm.DB){
+	
+	// add pgjwt functionality
+	addPgJwt(db)
+
+	// add other extensions
+	for _, extension_name := range []string{
+		"uuid-ossp",
+		"pgcrypto",
+	} {
+		addExtension(extension_name, db)
+	}
+
+	
+}

--- a/go-backend/models/extensions/extensions.go
+++ b/go-backend/models/extensions/extensions.go
@@ -128,6 +128,7 @@ func MigrateExtensions(db *gorm.DB){
 	for _, extension_name := range []string{
 		"uuid-ossp",
 		"pgcrypto",
+		"pg_trgm",
 	} {
 		addExtension(extension_name, db)
 	}

--- a/go-backend/models/functions/auth.go
+++ b/go-backend/models/functions/auth.go
@@ -1,0 +1,62 @@
+package functions
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"gorm.io/gorm"
+)
+
+
+func SessionLogin (db *gorm.DB) {
+	err := db.Exec(fmt.Sprintf(`
+	  create or replace function login (token text)
+	  returns void as $$
+	  declare claims json;
+	  declare id text;
+	  begin
+		claims := jwt.verify(token, %s);
+		id := claims->sub::text;
+		perform
+			set_config('request.jwt.claim.sub', id::text, TRUE);
+	  end;
+	  $$ language plpgsql;
+	`, os.Getenv("AUTH0_SECRET"))).Error
+	if err != nil {
+		log.Printf("An error occured creating session login function:: %s", err)
+	}
+}
+
+
+func SessionLogout (db *gorm.DB) {
+	err := db.Exec(`
+		create or replace function logout ()
+		returns void as $$
+			begin
+				perform
+					set_config('request.jwt.claim.sub', NULL, TRUE);
+			end;
+		$$ language plpgsql;
+	`).Error
+
+	if err != nil {
+		log.Printf("An error occured logging out of session:: %s", err)
+	}
+}
+
+
+func GetSessionUID (db *gorm.DB) {
+	err := db.Exec(`
+		create or replace function uid ()
+		returns uuid as
+		$$
+			select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
+		$$ language sql stable;
+	`).Error
+
+	if err != nil {
+		log.Printf("An error occured creating get uid function,:: %s", err)
+	}
+
+}

--- a/go-backend/models/functions/data.go
+++ b/go-backend/models/functions/data.go
@@ -1,0 +1,72 @@
+package functions
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+type funcDef struct {
+	name	string
+	parameters	[]string
+	declaration	string
+	body	string
+	returns	string
+}
+
+
+func (def *funcDef) genFunction() string {
+	
+	parameters := (func()string{
+		if len(def.parameters) == 0 {
+			return ""
+		}else {
+			return strings.Join(def.parameters, ", ")
+		}
+	})()
+	str := fmt.Sprintf(`
+		create or replace function %s ( %s )
+		returns %s as
+		$$
+			%s ;
+			begin
+				%s
+			end;
+		$$ language plpgsql;
+	`, def.name, parameters, def.returns, def.declaration, def.body )
+	return str
+}
+
+
+func (def *funcDef) runFunc (db *gorm.DB, str string) {
+	err := db.Exec(str).Error
+
+	if err != nil {
+		log.Fatalf("An error occured while working on function %s", err)
+	}
+
+}
+
+func NewFuncMigrate (db *gorm.DB) {
+
+	for _, def := range []funcDef{
+		{
+			name: "get_places",
+			returns: "public.places[]",
+			declaration: `
+				declare a public.places[]
+			`,
+			body: `
+				select * into a
+				from public.places;
+				return a;
+			`,
+		},
+	} {
+		d := def.genFunction()
+		def.runFunc(db, d)
+	}
+
+}

--- a/go-backend/models/functions/functions.go
+++ b/go-backend/models/functions/functions.go
@@ -4,6 +4,7 @@ import "gorm.io/gorm"
 
 
 func MigrateFunctions (db *gorm.DB) {
+	NewFuncMigrate(db)
 	SessionLogin(db)
 	SessionLogout(db)
 	GetSessionUID(db)

--- a/go-backend/models/functions/functions.go
+++ b/go-backend/models/functions/functions.go
@@ -1,0 +1,10 @@
+package functions
+
+import "gorm.io/gorm"
+
+
+func MigrateFunctions (db *gorm.DB) {
+	SessionLogin(db)
+	SessionLogout(db)
+	GetSessionUID(db)
+}

--- a/go-backend/models/keys.go
+++ b/go-backend/models/keys.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	"gorm.io/gorm"
+)
+
+
+type Keys struct {
+	ID		uuid.UUID		`gorm:"type:uuid;not null;primaryKey;default:uuid_generate_v4(); unique" json:"id"`
+	Key		string			`gorm:"type:text;not null" json:"key"`
+	CreatedOn	time.Time	`gorm:"type:timestamptz;default:now()" json:"created_on"`
+	UpdatedOn	time.Time	`gorm:"type:timestamptz;default:now()" json:"updated_on"`
+	Status		string		`gorm:"type:key_status;default:'active'" json:"status"`
+	Owner		uuid.UUID	`gorm:"type:uuid;not null;"`
+	Usage	[]Usage			`gorm:"type:uuid;foreignKey:Key;references:ID"`
+}
+
+func MigrateKeys(db *gorm.DB) {
+	err := db.AutoMigrate(&Keys{})
+
+	if err != nil {
+		log.Fatalf("Unable to migrate keys, encountered an error: %s", err)
+	}
+
+	fmt.Printf("Migrated Keys successfully!")
+
+}

--- a/go-backend/models/models.go
+++ b/go-backend/models/models.go
@@ -1,10 +1,16 @@
 package models
 
-import "gorm.io/gorm"
+import (
+	"geek-stash/models/extensions"
+	"geek-stash/models/functions"
+
+	"gorm.io/gorm"
+)
 
 
 func RunAllMigrations(db *gorm.DB){
-
+	//Migrate Extensions
+	extensions.MigrateExtensions(db)
 	//Profile
 	MigrateProfile(db)
 	//Franchise
@@ -17,5 +23,7 @@ func RunAllMigrations(db *gorm.DB){
 	MigrateSpecie(db)
 	//Characters
 	MigrateCharacter(db)
+	//Functions
+	functions.MigrateFunctions(db)
 	
 }

--- a/go-backend/models/models.go
+++ b/go-backend/models/models.go
@@ -3,12 +3,15 @@ package models
 import (
 	"geek-stash/models/extensions"
 	"geek-stash/models/functions"
+	"geek-stash/models/setup"
 
 	"gorm.io/gorm"
 )
 
 
 func RunAllMigrations(db *gorm.DB){
+	//Setup
+	setup.Setup(db)
 	//Migrate Extensions
 	extensions.MigrateExtensions(db)
 	//Profile
@@ -23,6 +26,10 @@ func RunAllMigrations(db *gorm.DB){
 	MigrateSpecie(db)
 	//Characters
 	MigrateCharacter(db)
+	//Keys
+	MigrateKeys(db)
+	//Usage
+	MigrateUsage(db)
 	//Functions
 	functions.MigrateFunctions(db)
 	

--- a/go-backend/models/profile.go
+++ b/go-backend/models/profile.go
@@ -19,6 +19,7 @@ type Profile struct {
 	Specie		[]Specie	`gorm:"foreignKey:CreatedBy;references:ID"`
 	Character	[]Character	`gorm:"foreignKey:CreatedBy;references:ID"`
 	Place		[]Place		`gorm:"foreignKey:CreatedBy;references:ID"`
+	Keys		[]Keys		`gorm:"foreignKey:Owner;references:ID"`
 }
 
 func MigrateProfile (db *gorm.DB) {

--- a/go-backend/models/setup/setup.go
+++ b/go-backend/models/setup/setup.go
@@ -1,0 +1,9 @@
+package setup
+
+import "gorm.io/gorm"
+
+
+func Setup ( db *gorm.DB ) {
+	//Types
+	RegisterUserTypes(db)
+}

--- a/go-backend/models/setup/types.go
+++ b/go-backend/models/setup/types.go
@@ -1,0 +1,48 @@
+package setup
+
+import (
+	"fmt"
+	"log"
+
+	"gorm.io/gorm"
+)
+
+type tDef struct {
+	ntype	string
+	definition	string
+}
+
+func NewType (type_name string, definition string) string {
+	str := fmt.Sprintf(`
+	DO $$
+	BEGIN
+	   IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = '%s') THEN
+		  CREATE TYPE %s as %s;
+	   END IF;
+	END $$;
+	`, type_name, type_name, definition)
+
+	return str
+}
+
+// Will have to add other related types later
+func RegisterUserTypes (db *gorm.DB) {
+
+	for _, t_def := range []tDef{
+		{
+			ntype: "key_status",
+			definition: "enum('active', 'inactive')",
+		},
+		{
+			ntype: "usage_status",
+			definition: "enum('success', 'error')",
+		},
+	} {
+		err := db.Exec(NewType(t_def.ntype, t_def.definition)).Error
+
+		if err != nil {
+			log.Fatalf("Unable to create type:: %s \n Error ::: %s", t_def.ntype, err)
+		}
+	}
+
+}

--- a/go-backend/models/usage.go
+++ b/go-backend/models/usage.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"log"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	"gorm.io/gorm"
+)
+
+
+type Usage struct {
+	ID		uuid.UUID		`gorm:"type:uuid;unique;not null;primaryKey;default:uuid_generate_v4();" json:"id"`
+	CreatedOn	time.Time	`gorm:"type:timestamptz;not null;default:now()" json:"created_on"`
+	Status		string		`gorm:"type:usage_status;not null;default:'success'" json:"status"`
+	Key		uuid.UUID		`gorm:"type:uuid;not null;" json:"key"`
+}
+
+
+func MigrateUsage ( db *gorm.DB) {
+	err := db.AutoMigrate(&Usage{})
+
+	if err != nil {
+		log.Fatalf("An error occured %s", err)
+	}
+}

--- a/go-backend/repository/repository.go
+++ b/go-backend/repository/repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"geek-stash/dtos"
 	"geek-stash/handlers"
+	"geek-stash/middleware"
 	"geek-stash/models"
 	"geek-stash/storage"
 	"log"
@@ -13,8 +14,8 @@ import (
 	// "time"
 
 	"github.com/gofiber/fiber/v2"
-	"gorm.io/gorm"
 	"github.com/gofiber/fiber/v2/middleware/logger"
+	"gorm.io/gorm"
 )
 
 
@@ -56,6 +57,7 @@ func InitRepo () Repository {
 func (repo *Repository) SetupRoutes(app *fiber.App){
 
 	app.Use(logger.New())
+	app.Use(middleware.Auth)
 	api := app.Group("/api")
 
 	//ping
@@ -76,6 +78,9 @@ func (repo *Repository) SetupRoutes(app *fiber.App){
 
 	//Specie
 	api.Post("specie/create", repo.CreateSpecie)
+
+	//Keys
+	api.Post("keys/new", repo.GenerateKeys)
 
 }
 
@@ -135,6 +140,7 @@ func (repo *Repository) CreateProfile(context *fiber.Ctx) error {
 }
 
 func (repo *Repository) GetFranchises(context *fiber.Ctx) error {
+	// middleware.SetDBSession(repo.DB, context)
 	franchiseModel := &[]models.Franchise{}
 	franchise_id := context.Query("id")
 	size, s_err := strconv.Atoi(context.Query("size"))
@@ -161,4 +167,10 @@ func (repo *Repository) GetFranchises(context *fiber.Ctx) error {
 	context.Status(http.StatusOK).JSON(&fiber.Map{"message": "Entities recieved successfully", "entities": franchiseModel, "status": 200})
 
 	return nil
+}
+
+//Keys ------------------------
+	// ----------Generate------
+func (repo *Repository) GenerateKeys(context *fiber.Ctx) error {
+	return handlers.KeyGen(repo.DB, context)
 }


### PR DESCRIPTION
# Description of changes
- I really wanted to implement functionality similar to supabase, however I still don't have any idea(even with chatgpt's help 😁) of how to implement row level security policies based on individual user sessions, the same way supabase has the handy `auth.uid()` function. So for now this represents a split point, and I'll continue to work with  all the user session auth on the backend, and none on the database. 
- However, in the future, I can come back to this point and continue with a different approach.